### PR TITLE
For PR regarding Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
+# syntax=docker/dockerfile:1
 FROM node
+
+# Wrangler npm package
+RUN npm install -g wrangler
 
 # Update default packages
 RUN apt-get -qq update
@@ -8,17 +12,19 @@ RUN apt-get install -y -q \
     build-essential \
     curl
 
+# Rustup
 RUN curl https://sh.rustup.rs -sSf | \
     sh -s -- --default-toolchain stable -y
 
 # Add .cargo/bin to PATH
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-RUN cargo install worker-build
+# Following commands will be executed using 
+# bash shell 
+SHELL [ "/bin/bash", "-c" ]
 
-ENV PATH="/root/.worker-build/bin:${PATH}"
-
-SHELL ["/bin/bash","-c"]
-
-# Check cargo is visible
-RUN cargo --help
+# Install Cargo Crates
+# wasm-pack worker-build 
+RUN cargo install wasm-pack worker-build
+# worker-rs
+RUN cargo install -q --git https://github.com/cloudflare/workers-rs


### PR DESCRIPTION
As I am unaware of how the github actions are set on the OG repo, cloning the target git repo `infinibuild-api` and cloudflare config is left for later. 

Run `Dockerfile` to create an image which is ready for cloudflare worker-build and wrangler dev and deploy of a project.